### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+
+before_script:
+  - travis_retry composer install -n
+
+script:
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Introduction
+[![Build Status](https://travis-ci.org/HylianShield/number-generator.svg?branch=master)](https://travis-ci.org/HylianShield/number-generator)
 
 Generate a number or a list of numbers between a given minimum and maximum.
 The default implementation is based on the

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,16 @@
     "php": "^7.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7.5"
+    "phpunit/phpunit": "^6.5"
   },
   "autoload": {
     "psr-4": {
       "HylianShield\\NumberGenerator\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "HylianShield\\NumberGenerator\\Tests\\": "tests"
     }
   },
   "scripts": {

--- a/tests/NumberGeneratorTest.php
+++ b/tests/NumberGeneratorTest.php
@@ -2,11 +2,12 @@
 namespace HylianShield\NumberGenerator\Tests;
 
 use HylianShield\NumberGenerator\NumberGenerator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \HylianShield\NumberGenerator\NumberGenerator
  */
-class NumberGeneratorTest extends \PHPUnit_Framework_TestCase
+class NumberGeneratorTest extends TestCase
 {
     /** @var NumberGenerator */
     private $generator;


### PR DESCRIPTION
# Changed log
- Add the Travis CI build. Please see the [Travis CI build log](https://travis-ci.org/peter279k/number-generator).
- Upgrade the PHPUnit version to support the ```php-7+```.
- Use the class-based PHPUnit namespace.
- It's related to this [issue](https://github.com/HylianShield/number-generator/issues/1).